### PR TITLE
Added Auto Claiming

### DIFF
--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -14,6 +14,7 @@ public class CapitolConfig {
 	public static final ModConfigSpec.EnumValue<ListType> CLAIMABLE_DIMENSIONS_LIST_TYPE;
 	public static final ModConfigSpec.ConfigValue<List<? extends String>> CLAIMABLE_DIMENSIONS;
 	public static final ModConfigSpec.BooleanValue SUBLEVEL_CLAIM_OVERLAP;
+	public static final ModConfigSpec.DoubleValue AUTO_CLAIM_COOLDOWN;
 
 	// Forceloading
 	public static final ModConfigSpec.BooleanValue FORCELOAD_ENABLED;
@@ -78,6 +79,11 @@ public class CapitolConfig {
 				"This is good to use if you are worried about players being able to grief with sub-levels,",
 				"or don't want a looming airship over your base you can't do anything about")
 				.define("sublevelClaimOverlap", true);
+
+		AUTO_CLAIM_COOLDOWN = builder
+			.comment("How long a player must wait before being able to claim the next chunk while autoclaiming.",
+				"Given in seconds.")
+				.defineInRange("autoClaimCooldown", 1.0, 0, Integer.MAX_VALUE);
 
 		builder.pop();
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/claim/ClaimCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/claim/ClaimCommand.java
@@ -7,6 +7,7 @@ import com.createcivilization.capitol.common.data.Team;
 import com.createcivilization.capitol.common.managers.DatabaseManager;
 import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
 import com.createcivilization.capitol.common.networking.packets.S2CChunkData;
+import com.createcivilization.capitol.server.events.AutoClaimEvents;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
@@ -28,6 +29,9 @@ public class ClaimCommand {
 		LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal("claim")
 			.then(Commands.literal("chunk")
 				.executes(ClaimCommand::claim));
+
+		builder.then(Commands.literal("auto")
+			.executes(ClaimCommand::auto));
 
 		if (SableCompat.LOADED) {
 			builder.then(Commands.literal("sub_level")
@@ -149,6 +153,32 @@ public class ClaimCommand {
 			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.claim.info.owner",
 				Component.literal(owner.getName()).withStyle(ChatFormatting.GOLD))
 				.withStyle(ChatFormatting.GRAY), false);
+		}
+		return 1;
+	}
+
+	private static int auto(CommandContext<CommandSourceStack> context) {
+		CapitolDatabase database = DatabaseManager.database;
+		Player player = context.getSource().getPlayer();
+		if (player == null) return 0;
+
+		Team team = database.getPlayerTeam(player);
+		if (team == null) {
+			context.getSource().sendFailure(Component.translatable("commands.capitol.not_in_team_error").withStyle(ChatFormatting.RED));
+			return 0;
+		}
+
+		if (!Permission.CLAIM_CHUNKS.hasPermission(database.getPlayerPermission(player, team))) {
+			context.getSource().sendFailure(Component.translatable("commands.capitol.claim.no_permission").withStyle(ChatFormatting.RED));
+			return 0;
+		}
+
+		if (AutoClaimEvents.isAutoClaimer(player)) {
+			AutoClaimEvents.removeAutoClaimer(player);
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.claim.auto_claim.stop").withStyle(ChatFormatting.GREEN), true);
+		} else {
+			AutoClaimEvents.addAutoClaimer(player);
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.claim.auto_claim.start").withStyle(ChatFormatting.GREEN), true);
 		}
 		return 1;
 	}

--- a/src/main/java/com/createcivilization/capitol/server/commands/claim/ClaimCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/claim/ClaimCommand.java
@@ -177,7 +177,7 @@ public class ClaimCommand {
 			AutoClaimEvents.removeAutoClaimer(player);
 			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.claim.auto_claim.stop").withStyle(ChatFormatting.GREEN), true);
 		} else {
-			AutoClaimEvents.addAutoClaimer(player);
+			AutoClaimEvents.updateAutoClaimer(player);
 			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.claim.auto_claim.start").withStyle(ChatFormatting.GREEN), true);
 		}
 		return 1;

--- a/src/main/java/com/createcivilization/capitol/server/commands/help/HelpCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/help/HelpCommand.java
@@ -23,6 +23,7 @@ public class HelpCommand {
 		msg.append(entry("/capitol claim sub_level", Component.translatable("commands.capitol.help.claim.sub_level")));
 		msg.append(entry("/capitol claim info", Component.translatable("commands.capitol.help.claim.info")));
 		msg.append(entry("/capitol claim info sub_level", Component.translatable("commands.capitol.help.claim.info.sub_level")));
+		msg.append(entry("/capitol claim auto", Component.translatable("commands.capitol.help.claim.auto")));
 		msg.append(entry("/capitol unclaim chunk", Component.translatable("commands.capitol.help.unclaim.chunk")));
 		msg.append(entry("/capitol unclaim sub_level", Component.translatable("commands.capitol.help.unclaim.sub_level")));
 		msg.append(entry("/capitol team create <name> <tag> <color> [desc]", Component.translatable("commands.capitol.help.team.create")));

--- a/src/main/java/com/createcivilization/capitol/server/events/AutoClaimEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/AutoClaimEvents.java
@@ -23,60 +23,58 @@ import java.util.*;
 
 @EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
 public class AutoClaimEvents {
-	private static final Map<Player, Long> autoClaimingPlayers = new HashMap<>();
+	private static final Map<UUID, Long> autoClaimingPlayers = new HashMap<>();
 
 	@SubscribeEvent
 	public static void onEntityEnterSection(EntityEvent.EnteringSection event) {
-		if (event.getEntity() instanceof Player player) {
-			if (!event.didChunkChange()) {
+		if (!event.didChunkChange() || !(event.getEntity() instanceof Player player)) {
+			return;
+		}
+		if (isAutoClaimer(player)) {
+			if (Calendar.getInstance().getTimeInMillis() - autoClaimingPlayers.get(player.getUUID()) < CapitolConfig.AUTO_CLAIM_COOLDOWN.get() * 1000) {
+				player.displayClientMessage(Component.translatable("commands.capitol.claim.auto_claim.too_fast").withStyle(ChatFormatting.RED), false);
 				return;
 			}
-			if (autoClaimingPlayers.containsKey(player)) {
-				if (Calendar.getInstance().getTimeInMillis()-autoClaimingPlayers.get(player) < CapitolConfig.AUTO_CLAIM_COOLDOWN.get() * 1000) {
-					player.displayClientMessage(Component.translatable("commands.capitol.claim.auto_claim.too_fast").withStyle(ChatFormatting.RED), false);
-					return;
-				}
 
-				CapitolDatabase database = DatabaseManager.database;
+			CapitolDatabase database = DatabaseManager.database;
 
-				Team team = database.getPlayerTeam(player);
-				if (team == null) {
-					player.displayClientMessage(Component.translatable("commands.capitol.not_in_team_error").withStyle(ChatFormatting.RED), false);
-					return;
-				}
-
-				if (!Permission.CLAIM_CHUNKS.hasPermission(database.getPlayerPermission(player, team))) {
-					player.displayClientMessage(Component.translatable("commands.capitol.claim.no_permission").withStyle(ChatFormatting.RED), false);
-					return;
-				}
-
-				int serverLimit = CapitolConfig.MAX_TEAM_CLAIMS.get();
-				int teamLimit = team.getMaxClaims();
-				int effectiveLimit = (teamLimit > 0) ? Math.min(serverLimit, teamLimit) : serverLimit;
-
-				if (team.getCurrentClaims() >= effectiveLimit) {
-					boolean isServerLimit = (teamLimit <= 0) || (serverLimit <= teamLimit);
-					String limitName = isServerLimit ? "server" : "team";
-					int limitValue = isServerLimit ? serverLimit : teamLimit;
-					player.displayClientMessage(Component.translatable("commands.capitol.claim.limit_reached", limitName, limitValue).withStyle(ChatFormatting.RED), false);
-					return;
-				}
-
-				ChunkPos chunkPos = player.chunkPosition();
-				Team existingOwner = database.getChunkOwner(chunkPos, player.level());
-				if (existingOwner != null) {
-					player.displayClientMessage(Component.translatable("commands.capitol.claim.already_claimed", existingOwner.getName()).withStyle(ChatFormatting.RED), false);
-					return;
-				}
-
-				database.claimChunk(team, chunkPos, player.level());
-				S2CChunkData packet = new S2CChunkData(chunkPos.toLong(), team);
-				PacketDistributor.sendToPlayersTrackingChunk((ServerLevel) player.level(), chunkPos, packet);
-
-				player.displayClientMessage(Component.translatable("commands.capitol.claim.success").withStyle(ChatFormatting.GREEN), false);
-
-				autoClaimingPlayers.put(player, Calendar.getInstance().getTimeInMillis());
+			Team team = database.getPlayerTeam(player);
+			if (team == null) {
+				player.displayClientMessage(Component.translatable("commands.capitol.not_in_team_error").withStyle(ChatFormatting.RED), false);
+				return;
 			}
+
+			if (!Permission.CLAIM_CHUNKS.hasPermission(database.getPlayerPermission(player, team))) {
+				player.displayClientMessage(Component.translatable("commands.capitol.claim.no_permission").withStyle(ChatFormatting.RED), false);
+				return;
+			}
+
+			int serverLimit = CapitolConfig.MAX_TEAM_CLAIMS.get();
+			int teamLimit = team.getMaxClaims();
+			int effectiveLimit = (teamLimit > 0) ? Math.min(serverLimit, teamLimit) : serverLimit;
+
+			if (team.getCurrentClaims() >= effectiveLimit) {
+				boolean isServerLimit = (teamLimit <= 0) || (serverLimit <= teamLimit);
+				String limitName = isServerLimit ? "server" : "team";
+				int limitValue = isServerLimit ? serverLimit : teamLimit;
+				player.displayClientMessage(Component.translatable("commands.capitol.claim.limit_reached", limitName, limitValue).withStyle(ChatFormatting.RED), false);
+				return;
+			}
+
+			ChunkPos chunkPos = player.chunkPosition();
+			Team existingOwner = database.getChunkOwner(chunkPos, player.level());
+			if (existingOwner != null) {
+				player.displayClientMessage(Component.translatable("commands.capitol.claim.already_claimed", existingOwner.getName()).withStyle(ChatFormatting.RED), false);
+				return;
+			}
+
+			database.claimChunk(team, chunkPos, player.level());
+			S2CChunkData packet = new S2CChunkData(chunkPos.toLong(), team);
+			PacketDistributor.sendToPlayersTrackingChunk((ServerLevel) player.level(), chunkPos, packet);
+
+			player.displayClientMessage(Component.translatable("commands.capitol.claim.success").withStyle(ChatFormatting.GREEN), false);
+
+			updateAutoClaimer(player);
 		}
 	}
 
@@ -85,15 +83,21 @@ public class AutoClaimEvents {
 		removeAutoClaimer(e.getEntity()); // avoids a small memory leak, also disables auto-claiming on disconnect
 	}
 
-	public static void addAutoClaimer(Player p) {
-		autoClaimingPlayers.put(p, Calendar.getInstance().getTimeInMillis());
+	/**
+	 *	Updates the last time that a player has claimed a tile through auto claiming.
+	 *	Adds the player to the list if they haven't already claimed.
+	 *
+	 * @param player player to be added / updated
+	 */
+	public static void updateAutoClaimer(Player player) {
+		autoClaimingPlayers.put(player.getUUID(), System.currentTimeMillis());
 	}
 
 	public static void removeAutoClaimer(Player p) {
-		autoClaimingPlayers.remove(p);
+		autoClaimingPlayers.remove(p.getUUID());
 	}
 
 	public static boolean isAutoClaimer(Player p) {
-		return autoClaimingPlayers.containsKey(p);
+		return autoClaimingPlayers.containsKey(p.getUUID());
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/server/events/AutoClaimEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/AutoClaimEvents.java
@@ -1,0 +1,99 @@
+package com.createcivilization.capitol.server.events;
+
+import com.createcivilization.capitol.Capitol;
+import com.createcivilization.capitol.common.config.CapitolConfig;
+import com.createcivilization.capitol.common.data.Permission;
+import com.createcivilization.capitol.common.data.Team;
+import com.createcivilization.capitol.common.managers.DatabaseManager;
+import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
+import com.createcivilization.capitol.common.networking.packets.S2CChunkData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ChunkPos;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.EntityEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.*;
+
+@EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
+public class AutoClaimEvents {
+	private static final Map<Player, Long> autoClaimingPlayers = new HashMap<>();
+
+	@SubscribeEvent
+	public static void onEntityEnterSection(EntityEvent.EnteringSection event) {
+		if (event.getEntity() instanceof Player player) {
+			if (!event.didChunkChange()) {
+				return;
+			}
+			if (autoClaimingPlayers.containsKey(player)) {
+				if (Calendar.getInstance().getTimeInMillis()-autoClaimingPlayers.get(player) < CapitolConfig.AUTO_CLAIM_COOLDOWN.get() * 1000) {
+					player.displayClientMessage(Component.translatable("commands.capitol.claim.auto_claim.too_fast").withStyle(ChatFormatting.RED), false);
+					return;
+				}
+
+				CapitolDatabase database = DatabaseManager.database;
+
+				Team team = database.getPlayerTeam(player);
+				if (team == null) {
+					player.displayClientMessage(Component.translatable("commands.capitol.not_in_team_error").withStyle(ChatFormatting.RED), false);
+					return;
+				}
+
+				if (!Permission.CLAIM_CHUNKS.hasPermission(database.getPlayerPermission(player, team))) {
+					player.displayClientMessage(Component.translatable("commands.capitol.claim.no_permission").withStyle(ChatFormatting.RED), false);
+					return;
+				}
+
+				int serverLimit = CapitolConfig.MAX_TEAM_CLAIMS.get();
+				int teamLimit = team.getMaxClaims();
+				int effectiveLimit = (teamLimit > 0) ? Math.min(serverLimit, teamLimit) : serverLimit;
+
+				if (team.getCurrentClaims() >= effectiveLimit) {
+					boolean isServerLimit = (teamLimit <= 0) || (serverLimit <= teamLimit);
+					String limitName = isServerLimit ? "server" : "team";
+					int limitValue = isServerLimit ? serverLimit : teamLimit;
+					player.displayClientMessage(Component.translatable("commands.capitol.claim.limit_reached", limitName, limitValue).withStyle(ChatFormatting.RED), false);
+					return;
+				}
+
+				ChunkPos chunkPos = player.chunkPosition();
+				Team existingOwner = database.getChunkOwner(chunkPos, player.level());
+				if (existingOwner != null) {
+					player.displayClientMessage(Component.translatable("commands.capitol.claim.already_claimed", existingOwner.getName()).withStyle(ChatFormatting.RED), false);
+					return;
+				}
+
+				database.claimChunk(team, chunkPos, player.level());
+				S2CChunkData packet = new S2CChunkData(chunkPos.toLong(), team);
+				PacketDistributor.sendToPlayersTrackingChunk((ServerLevel) player.level(), chunkPos, packet);
+
+				player.displayClientMessage(Component.translatable("commands.capitol.claim.success").withStyle(ChatFormatting.GREEN), false);
+
+				autoClaimingPlayers.put(player, Calendar.getInstance().getTimeInMillis());
+			}
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPlayerDisconnect(PlayerEvent.PlayerLoggedOutEvent e) {
+		removeAutoClaimer(e.getEntity()); // avoids a small memory leak, also disables auto-claiming on disconnect
+	}
+
+	public static void addAutoClaimer(Player p) {
+		autoClaimingPlayers.put(p, Calendar.getInstance().getTimeInMillis());
+	}
+
+	public static void removeAutoClaimer(Player p) {
+		autoClaimingPlayers.remove(p);
+	}
+
+	public static boolean isAutoClaimer(Player p) {
+		return autoClaimingPlayers.containsKey(p);
+	}
+}

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -96,9 +96,9 @@
 	"commands.capitol.claim.info.unclaimed": "This chunk is not claimed",
 	"commands.capitol.claim.info.owner": "Claimed by %s",
 	"commands.capitol.claim.sub_level.info.unclaimed": "This sub-level is not claimed",
-	"commands.capitol.claim.auto_claim.too_fast": "You are claiming too quickly!",
-	"commands.capitol.claim.auto_claim.start": "Started auto claiming.",
-	"commands.capitol.claim.auto_claim.stop": "Stopped auto claiming.",
+	"commands.capitol.claim.auto_claiming.too_fast": "You are claiming too quickly!",
+	"commands.capitol.claim.auto_claiming.start": "Started auto claiming.",
+	"commands.capitol.claim.auto_claiming.stop": "Stopped auto claiming.",
 
 	"commands.capitol.unclaim.no_permission": "You do not have permission to unclaim chunks",
 	"commands.capitol.unclaim.not_claimed": "This chunk is not claimed",

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -96,6 +96,9 @@
 	"commands.capitol.claim.info.unclaimed": "This chunk is not claimed",
 	"commands.capitol.claim.info.owner": "Claimed by %s",
 	"commands.capitol.claim.sub_level.info.unclaimed": "This sub-level is not claimed",
+	"commands.capitol.claim.auto_claim.too_fast": "You are claiming too quickly!",
+	"commands.capitol.claim.auto_claim.start": "Started auto claiming.",
+	"commands.capitol.claim.auto_claim.stop": "Stopped auto claiming.",
 
 	"commands.capitol.unclaim.no_permission": "You do not have permission to unclaim chunks",
 	"commands.capitol.unclaim.not_claimed": "This chunk is not claimed",

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -132,5 +132,6 @@
 	"commands.capitol.help.team.protection": "Toggle a claim protection setting",
 	"commands.capitol.help.team.player.permission": "Toggle an individual permission override",
 	"commands.capitol.help.team.player.permission.reset": "Reset a player's individual permission overrides",
-	"commands.capitol.help.invites": "Accept or deny a team invite"
+	"commands.capitol.help.invites": "Accept or deny a team invite",
+	"commands.capitol.help.claim.auto": "Toggles auto claiming mode, while in auto mode walk into unclaimed chunks to claim them."
 }


### PR DESCRIPTION
Added a small command that lets players toggle a auto claiming mode on or off.
While in auto mode and new chunks they enter will automatically be claimed for their team.

Theres a configurable cooldown inbetween claims, defaulted to one second between claims.

Currently all of the code for managing who is currently claiming is stored in the AutoClaimEvents class, but if needed I can seperate it into a manager.