### PR TITLE
Added permissions to the default role.

### DIFF
--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -35,6 +35,6 @@ public record TeamRole(int id, UUID teamId, String name, long permissions) {
 	}
 
 	public static long defaultPermissions() {
-		return Permission.of();
+		return 0b111111111111111111100000000L;
 	}
 }


### PR DESCRIPTION
Contains all authorization except admin perms.

This helps streamline the setup of a new nation, since teams only have an invite function for most cases people expect to be given permissions when invited.
If there was an option for people to join a team without an invite or password join it might be better to reduce how much people are given.

However, as it stands i believe its a fair assumption that player are only invited if they are trusted and not require teams to setup a new role with permissions / update the default role to have more.