### PR TITLE
Default "Member" Role.

### DIFF
--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -35,6 +35,6 @@ public record TeamRole(int id, UUID teamId, String name, long permissions) {
 	}
 
 	public static long defaultPermissions() {
-		return Permission.of();
+		return 0b111111111111111111100000000L;
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -39,7 +39,28 @@ public record TeamRole(int id, UUID teamId, String name, long permissions) {
 	}
 
 	public static long memberPermissions() {
-		return 0b111111111111111111100000000L;
+		return Permission.of(
+			Permission.BREAK_BLOCKS,
+			Permission.PLACE_BLOCKS,
+			Permission.INTERACT_BLOCKS,
+			Permission.OPEN_CONTAINERS,
+			Permission.CROP_TRAMPLE,
+			Permission.FROST_WALKING,
+			Permission.INTERACT_ENTITIES,
+			Permission.ATTACK_PASSIVE,
+			Permission.ATTACK_HOSTILE,
+			Permission.ATTACK_PLAYER,
+			Permission.USE_ITEMS,
+			Permission.PICKUP_ITEMS,
+			Permission.PICKUP_XP,
+			Permission.DROP_ITEMS,
+			Permission.MOB_LOOT,
+			Permission.PLAYER_DEATH_LOOT,
+			Permission.INTERACT_REDSTONE,
+			Permission.USE_NETHER_PORTALS,
+			Permission.CHORUS_FRUIT_TELEPORT
+		);
+		// return 0b111111111111111111100000000L;
 	}
 	public static long defaultPermissions() {
 		return 0;

--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -7,12 +7,16 @@ import java.util.UUID;
 public record TeamRole(int id, UUID teamId, String name, long permissions) {
 
 	public static final String OWNER_ROLE_NAME = "owner";
+	public static final String MEMBER_ROLE_NAME = "member";
 	public static final String DEFAULT_ROLE_NAME = "default";
 
 	public boolean isOwner() {
 		return OWNER_ROLE_NAME.equals(name);
 	}
 
+	public boolean isMemberRole() {
+		return MEMBER_ROLE_NAME.equals(name);
+	}
 	public boolean isDefaultRole() {
 		return DEFAULT_ROLE_NAME.equals(name);
 	}
@@ -34,7 +38,10 @@ public record TeamRole(int id, UUID teamId, String name, long permissions) {
 		return Permission.of(Permission.values());
 	}
 
-	public static long defaultPermissions() {
+	public static long memberPermissions() {
 		return 0b111111111111111111100000000L;
+	}
+	public static long defaultPermissions() {
+		return 0;
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
+++ b/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
@@ -166,6 +166,16 @@ public class CapitolDatabase extends Database {
 	}
 
 	/**
+	 * Convenience method that returns the "member" role for a team.
+	 *
+	 * @param team the team to query
+	 * @return the default {@link TeamRole}, or {@code null} if not found
+	 */
+	public TeamRole getMemberRole(Team team) {
+		return getRoleByName(team, TeamRole.MEMBER_ROLE_NAME);
+	}
+
+	/**
 	 * Updates the permission bitfield for a role identified by team and role name.
 	 *
 	 * @param team        the team the role belongs to

--- a/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
+++ b/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
@@ -319,6 +319,7 @@ public class CapitolDatabase extends Database {
 		}
 
 		addRole(team, TeamRole.OWNER_ROLE_NAME, TeamRole.ownerPermissions());
+		addRole(team, TeamRole.MEMBER_ROLE_NAME, TeamRole.memberPermissions());
 		addRole(team, TeamRole.DEFAULT_ROLE_NAME, TeamRole.defaultPermissions());
 	}
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/invite/InviteCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/invite/InviteCommand.java
@@ -44,7 +44,7 @@ public class InviteCommand {
 		Team team = resolveInvitedTeam(context, player);
 		if (team == null) return 0;
 
-		TeamRole role = DatabaseManager.database.getDefaultRole(team);
+		TeamRole role = DatabaseManager.database.getMemberRole(team);
 		DatabaseManager.database.addPlayerToTeam(player, team, role);
 		InviteHandler.clearInvites(player);
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -124,6 +124,10 @@ class TeamRoleCommand {
 			return failCommand(context, "commands.capitol.team.role.remove.default");
 		}
 
+		if (Objects.equals(roleName, TeamRole.MEMBER_ROLE_NAME)) {
+			return failCommand(context, "commands.capitol.team.role.remove.member");
+		}
+
 		TeamRole role = database.getRoleByName(team, roleName);
 
 		if (role == null) {

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -62,7 +62,7 @@
 
 	"commands.capitol.team.role.remove.owner": "You cannot remove owner role.",
 	"commands.capitol.team.role.remove.default": "You cannot remove default role.",
-	"commands.capitol.team.role.remove.member": "You cannot remove member role.",
+	"commands.capitol.team.role.remove.member": "You cannot remove the 'member' role.",
 	"commands.capitol.team.role.remove.success": "Deleted role %s",
 
 	"commands.capitol.team.role.assign.no_permission": "You do not have permission to assign roles",

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -62,6 +62,7 @@
 
 	"commands.capitol.team.role.remove.owner": "You cannot remove owner role.",
 	"commands.capitol.team.role.remove.default": "You cannot remove default role.",
+	"commands.capitol.team.role.remove.member": "You cannot remove member role.",
 	"commands.capitol.team.role.remove.success": "Deleted role %s",
 
 	"commands.capitol.team.role.assign.no_permission": "You do not have permission to assign roles",


### PR DESCRIPTION
This is meant to streamline the team creation process greatly.

Since most people wont want to modify the permissions beyond the basics, it makes the mod a lot easier to use if inviting a player immediately gives them access to the teams claims.

For this I created a "member" role, which is created alongside the default and owner roles on team creation. Any new invites are then assigned the member role, which by default gives all but administrative permissions.

These are all things that a team owner would have done when they made a new team, its just been automated now.