### PR TITLE
Permission viewer

### DIFF
--- a/src/main/java/com/createcivilization/capitol/server/commands/help/HelpCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/help/HelpCommand.java
@@ -31,7 +31,7 @@ public class HelpCommand {
 		msg.append(entry("/capitol team invite <player>", Component.translatable("commands.capitol.help.team.invite")));
 		msg.append(entry("/capitol team kick <player>", Component.translatable("commands.capitol.help.team.kick")));
 		msg.append(entry("/capitol team disband", Component.translatable("commands.capitol.help.team.disband")));
-		msg.append(entry("/capitol team role edit <name> remove|rename|assign|permission", Component.translatable("commands.capitol.help.team.role.edit")));
+		msg.append(entry("/capitol team role edit <name> remove|rename|assign|permission|list", Component.translatable("commands.capitol.help.team.role.edit")));
 		msg.append(entry("/capitol team role create <name>", Component.translatable("commands.capitol.help.team.role.create")));
 		msg.append(entry("/capitol team protection <name>", Component.translatable("commands.capitol.help.team.protection")));
 		msg.append(entry("/capitol team player <player> permission <perm>", Component.translatable("commands.capitol.help.team.player.permission")));

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -304,9 +304,9 @@ class TeamRoleCommand {
 		for (Permission perm : Permission.values()) {
 			MutableComponent comp = Component.literal("[").append(perm.hasPermission(role.permissions()) ? Component.literal("✔").withStyle(ChatFormatting.GREEN) : Component.literal("❌").withStyle(ChatFormatting.RED)).append("]");
 			comp.withStyle(s -> s.withClickEvent(
-				new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("", roleName, perm.name().toLowerCase()))
+				new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/capitol team role edit %s permission %s", roleName, perm.name().toLowerCase()))
 			).withHoverEvent(
-				new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to swap permissions"))
+				new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.translatable("commands.capitol.team.role.permission_list.hover"))
 			));
 			context.getSource().sendSuccess(() ->
 					comp.append(Component.literal(" ").withStyle(ChatFormatting.GOLD)).append(Component.literal(perm.name()).withStyle(ChatFormatting.WHITE))

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -10,7 +10,10 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.players.GameProfileCache;
 
 import java.util.List;
@@ -67,6 +70,7 @@ class TeamRoleCommand {
 							return builder.buildFuture();
 						})
 						.executes(TeamRoleCommand::editRolePerms)))
+					.then(Commands.literal("list").executes(TeamRoleCommand::viewRolePermList))
 				.then(Commands.literal("name")
 					.then(Commands.argument("new_name", StringArgumentType.string())
 						.executes(TeamRoleCommand::editRoleName)))
@@ -275,6 +279,46 @@ class TeamRoleCommand {
 			Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
 			Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
 			.withStyle(ChatFormatting.GRAY), true);
+		return 1;
+	}
+
+	private static int viewRolePermList(CommandContext<CommandSourceStack> context) {
+		CapitolDatabase database = DatabaseManager.database;
+		var player = context.getSource().getPlayer();
+		Team team = database.getPlayerTeam(player);
+		if (team == null) {
+			return failCommand(context, "commands.capitol.not_in_team_error");
+		}
+
+		String roleName = StringArgumentType.getString(context, "role_name");
+		TeamRole role = database.getRoleByName(team, roleName);
+
+		if (role == null) {
+			return failCommand(context, "commands.capitol.team.role.not_found", roleName, team.getName());
+		}
+
+		context.getSource().sendSuccess(() ->
+				Component.translatable("commands.capitol.team.role.permission_list.role").append(roleName).withStyle(ChatFormatting.GOLD)
+			, false);
+
+		for (Permission perm : Permission.values()) {
+			MutableComponent comp = Component.literal("[").append(perm.hasPermission(role.permissions()) ? Component.literal("✔").withStyle(ChatFormatting.GREEN) : Component.literal("❌").withStyle(ChatFormatting.RED)).append("]");
+			comp.withStyle(s -> s.withClickEvent(
+				new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("", roleName, perm.name().toLowerCase()))
+			).withHoverEvent(
+				new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to swap permissions"))
+			));
+			context.getSource().sendSuccess(() ->
+					comp.append(Component.literal(" ").withStyle(ChatFormatting.GOLD)).append(Component.literal(perm.name()).withStyle(ChatFormatting.WHITE))
+				, false);
+		}
+
+		/*context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.permission_toggle",
+				Component.literal(permissionName.toLowerCase()).withStyle(ChatFormatting.AQUA),
+				Component.literal(roleName).withStyle(ChatFormatting.GOLD),
+				Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
+				Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
+			.withStyle(ChatFormatting.GRAY), true);*/
 		return 1;
 	}
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
 
 import java.util.List;
@@ -284,7 +285,10 @@ class TeamRoleCommand {
 
 	private static int viewRolePermList(CommandContext<CommandSourceStack> context) {
 		CapitolDatabase database = DatabaseManager.database;
-		var player = context.getSource().getPlayer();
+		ServerPlayer player = context.getSource().getPlayer();
+		if (player == null) {
+			return failCommand(context, "commands.capitol.not_player");
+		}
 		Team team = database.getPlayerTeam(player);
 		if (team == null) {
 			return failCommand(context, "commands.capitol.not_in_team_error");

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -72,6 +72,8 @@
 	"commands.capitol.team.role.edit.no_default": "You cannot edit default role name.",
 	"commands.capitol.team.role.name.success": "Renamed role %s → %s",
 
+	"commands.capitol.team.role.permission_list.role": "Role: ",
+
 	"commands.capitol.team.player.no_permission": "You do not have permission to manage individual permissions",
 	"commands.capitol.team.player.perms.reset": "Individual permissions for %s reset to role defaults.",
 

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -18,7 +18,8 @@
 	"gui.journeymap.capitol.claim_chunk": "Claim chunk",
 	"gui.journeymap.capitol.unclaim_chunk": "Unclaim chunk",
 
-"commands.capitol.not_in_team_error": "You are not in any team",
+	"commands.capitol.not_player": "You must be a player to run this command.",
+	"commands.capitol.not_in_team_error": "You are not in any team",
 	"commands.capitol.no_player_found": "There is no player called %s",
 	"commands.capitol.player_not_in_team": "%s is not a member of %s",
 	"commands.capitol.invalid_permission": "%s is not a valid permission.",

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -73,6 +73,7 @@
 	"commands.capitol.team.role.name.success": "Renamed role %s → %s",
 
 	"commands.capitol.team.role.permission_list.role": "Role: ",
+	"commands.capitol.team.role.permission_list.hover": "Click to swap permissions",
 
 	"commands.capitol.team.player.no_permission": "You do not have permission to manage individual permissions",
 	"commands.capitol.team.player.perms.reset": "Individual permissions for %s reset to role defaults.",


### PR DESCRIPTION
Adds a new command:
/capitol team role edit <role> list

This displays a list of all the permissions and a interactable checkbox if its enabled or not.

<img width="991" height="508" alt="image" src="https://github.com/user-attachments/assets/7f7dab6d-e82e-47e2-9cda-637ba3743884" />

Clicking on any of the options runs the /capitol team role edit <role> permission <perm> command, flipping its value for that role.

<img width="519" height="509" alt="image" src="https://github.com/user-attachments/assets/d6ffdc3d-81d0-4be2-baf4-21894ea28f44" />

There isnt a clean way I know of to update the list when its clicked, so it remains static for now.