### PR TITLE
Team Tags

### DIFF
--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -55,7 +55,8 @@ public class CapitolConfig {
 
 	// Teams
 	public static final ModConfigSpec.IntValue TEAM_TAG_MAX_LENGTH;
-	public static final ModConfigSpec.ConfigValue<String> TEAM_TAG_FORMAT;
+	public static final ModConfigSpec.ConfigValue<String> TEAM_TAG_LIST_FORMAT;
+	public static final ModConfigSpec.ConfigValue<String> TEAM_TAG_CHAT_FORMAT;
 
 	public enum ListType {
 		ONLY,
@@ -196,10 +197,15 @@ public class CapitolConfig {
 			.comment("Max length for a team to have as a tag.")
 			.defineInRange("teamTagMaxLength", 3, 0, 16);
 
-		TEAM_TAG_FORMAT = builder
-			.comment("Format for rendering the players name in chat and the tab list. ",
+		TEAM_TAG_LIST_FORMAT = builder
+			.comment("Format for rendering the players name in the tab list. ",
 				"%t will be replaced with the team tag and %p will be replaced with the player name.")
-				.define("teamTagFormat", "[%t] %p");
+				.define("teamTagListFormat", "[%t] %p");
+
+		TEAM_TAG_CHAT_FORMAT = builder
+			.comment("Format for rendering the players name in chat. ",
+				"%t will be replaced with the team tag and %p will be replaced with the player name.")
+			.define("teamTagChatFormat", "<[%t] %p>");
 
 		builder.pop();
 

--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -55,6 +55,7 @@ public class CapitolConfig {
 
 	// Teams
 	public static final ModConfigSpec.IntValue TEAM_TAG_MAX_LENGTH;
+	public static final ModConfigSpec.ConfigValue<String> TEAM_TAG_FORMAT;
 
 	public enum ListType {
 		ONLY,
@@ -194,6 +195,11 @@ public class CapitolConfig {
 		TEAM_TAG_MAX_LENGTH = builder
 			.comment("Max length for a team to have as a tag.")
 			.defineInRange("teamTagMaxLength", 3, 0, 16);
+
+		TEAM_TAG_FORMAT = builder
+			.comment("Format for rendering the players name in chat and the tab list. ",
+				"%t will be replaced with the team tag and %p will be replaced with the player name.")
+				.define("teamTagFormat", "[%t] %p");
 
 		builder.pop();
 

--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -48,10 +48,13 @@ public class CapitolConfig {
 	public static final ModConfigSpec.ConfigValue<List<? extends String>> BLOCK_PLACE_EXCEPTIONS;
 	public static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_USE_EXCEPTIONS;
 
-	// Role Exceptions
+	// Roles
 
 	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_CHAT;
 	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_TAB_LIST;
+
+	// Teams
+	public static final ModConfigSpec.IntValue TEAM_TAG_MAX_LENGTH;
 
 	public enum ListType {
 		ONLY,
@@ -183,6 +186,14 @@ public class CapitolConfig {
 		DISPLAY_TAGS_IN_TAB_LIST = builder
 			.comment("Whether the tab list will have the players nation tag attached.")
 			.define("displayTagsInTabList", true);
+
+		builder.pop();
+
+		builder.comment("Role settings").push("team");
+
+		TEAM_TAG_MAX_LENGTH = builder
+			.comment("Max length for a team to have as a tag.")
+			.defineInRange("teamTagMaxLength", 3, 0, 16);
 
 		builder.pop();
 

--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -48,6 +48,11 @@ public class CapitolConfig {
 	public static final ModConfigSpec.ConfigValue<List<? extends String>> BLOCK_PLACE_EXCEPTIONS;
 	public static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_USE_EXCEPTIONS;
 
+	// Role Exceptions
+
+	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_CHAT;
+	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_TAB_LIST;
+
 	public enum ListType {
 		ONLY,
 		ALL_BUT
@@ -166,6 +171,18 @@ public class CapitolConfig {
 		ITEM_USE_EXCEPTIONS = builder
 			.comment("Items anyone can use in claims.")
 			.defineListAllowEmpty("itemUseExceptions", List.of(), () -> "", o -> o instanceof String);
+
+		builder.pop();
+
+		builder.comment("Role settings").push("roles");
+
+		DISPLAY_TAGS_IN_CHAT = builder
+			.comment("Whether chat messages with have the players nation tag attached.")
+			.define("displayTagsInChat", true);
+
+		DISPLAY_TAGS_IN_TAB_LIST = builder
+			.comment("Whether the tab list will have the players nation tag attached.")
+			.define("displayTagsInTabList", true);
 
 		builder.pop();
 

--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -50,6 +50,7 @@ public class CapitolConfig {
 
 	// Roles
 
+	public static final ModConfigSpec.BooleanValue ALLOW_PLAYER_ROLE_COLOURS;
 	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_CHAT;
 	public static final ModConfigSpec.BooleanValue DISPLAY_TAGS_IN_TAB_LIST;
 
@@ -180,6 +181,10 @@ public class CapitolConfig {
 		builder.pop();
 
 		builder.comment("Role settings").push("roles");
+
+		ALLOW_PLAYER_ROLE_COLOURS = builder
+			.comment("Wether or not players can choose colors for their roles. Defaults to team colour otherwise.")
+			.define("allowPlayerRoleColours", true);
 
 		DISPLAY_TAGS_IN_CHAT = builder
 			.comment("Whether chat messages with have the players team tag attached.")

--- a/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
+++ b/src/main/java/com/createcivilization/capitol/common/config/CapitolConfig.java
@@ -180,11 +180,11 @@ public class CapitolConfig {
 		builder.comment("Role settings").push("roles");
 
 		DISPLAY_TAGS_IN_CHAT = builder
-			.comment("Whether chat messages with have the players nation tag attached.")
+			.comment("Whether chat messages with have the players team tag attached.")
 			.define("displayTagsInChat", true);
 
 		DISPLAY_TAGS_IN_TAB_LIST = builder
-			.comment("Whether the tab list will have the players nation tag attached.")
+			.comment("Whether the tab list will have the players team tag attached.")
 			.define("displayTagsInTabList", true);
 
 		builder.pop();

--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -1,10 +1,11 @@
 package com.createcivilization.capitol.common.data;
 
+import java.awt.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
 
-public record TeamRole(int id, UUID teamId, String name, long permissions) {
+public record TeamRole(int id, UUID teamId, String name, long permissions, Color color) {
 
 	public static final String OWNER_ROLE_NAME = "owner";
 	public static final String DEFAULT_ROLE_NAME = "default";
@@ -22,11 +23,17 @@ public record TeamRole(int id, UUID teamId, String name, long permissions) {
 	}
 
 	public static TeamRole fromResultSet(ResultSet rs) throws SQLException {
+		Color color = null;
+		if (rs.getInt("color") != -1) {
+			color = new Color(rs.getInt("color"));
+		}
+
 		return new TeamRole(
 			rs.getInt("id"),
 			UUID.fromString(rs.getString("team_id")),
 			rs.getString("name"),
-			rs.getLong("permissions")
+			rs.getLong("permissions"),
+			color
 		);
 	}
 

--- a/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
+++ b/src/main/java/com/createcivilization/capitol/common/data/TeamRole.java
@@ -1,11 +1,12 @@
 package com.createcivilization.capitol.common.data;
 
+import javax.annotation.Nullable;
 import java.awt.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
 
-public record TeamRole(int id, UUID teamId, String name, long permissions, Color color) {
+public record TeamRole(int id, UUID teamId, String name, long permissions, @Nullable Color color) {
 
 	public static final String OWNER_ROLE_NAME = "owner";
 	public static final String MEMBER_ROLE_NAME = "member";

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -126,6 +126,7 @@ public class DatabaseManager {
 		if (SCHEMA_VERSION == current){
 			return;
 		}
+		Capitol.LOGGER.info("Schema out of date, updating to version " + SCHEMA_VERSION + " from version " + current);
 		int updates = SCHEMA_VERSION - current;
 		for (int version = current; version <= updates; ++version) {
 			// Runs for every update that has occured between now and the previous db version.

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -120,8 +120,26 @@ public class DatabaseManager {
 		}
 	}
 
+	public static int SCHEMA_VERSION = 1;
 	//Will be used for DB migrations ect
-	private static void runMigrations(int current) throws SQLException {}
+	private static void runMigrations(int current) throws SQLException {
+		if (SCHEMA_VERSION == current){
+			return;
+		}
+		int updates = SCHEMA_VERSION - current;
+		for (int version = current; version <= updates; ++version) {
+			// Runs for every update that has occured between now and the previous db version.
+			// E.G, current version 2 -> desired version 4 will result in versions
+			// 3 & 4 being run
+			switch (version) {
+				case 1:
+					try (Statement stmt = connection.createStatement()) {
+						stmt.execute("ALTER TABLE team_roles ADD COLUMN color INTEGER NOT NULL DEFAULT -1;");
+					}
+			}
+		}
+		setSchemaVersion(SCHEMA_VERSION);
+	}
 
 	private static int getSchemaVersion() throws SQLException {
 		try (ResultSet rs = connection.createStatement().executeQuery("PRAGMA user_version")) {

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -128,7 +128,7 @@ public class DatabaseManager {
 		if (SCHEMA_VERSION == current){
 			return;
 		}
-		if (current == 0) { // a schema of 0 means that the database is brand new, thus no migrations are needed
+		if (current == -1) { // a schema of 0 means that the database is brand new, thus no migrations are needed
 			setSchemaVersion(SCHEMA_VERSION);
 			return;
 		}
@@ -150,7 +150,7 @@ public class DatabaseManager {
 
 	private static int getSchemaVersion() throws SQLException {
 		try (ResultSet rs = connection.createStatement().executeQuery("PRAGMA user_version")) {
-			return rs.next() ? rs.getInt(1) : 0;
+			return rs.next() ? rs.getInt(1) : -1;
 		}
 	}
 

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -23,9 +23,6 @@ public class DatabaseManager {
 
 			connection = DriverManager.getConnection(url);
 
-			int version = getSchemaVersion();
-			runMigrations(version);
-
 			try (Statement stmt = connection.createStatement()) {
 				stmt.execute("PRAGMA journal_mode=WAL;");
 				stmt.execute("PRAGMA synchronous=NORMAL;");
@@ -33,6 +30,11 @@ public class DatabaseManager {
 			}
 
 			createTables();
+			Capitol.LOGGER.info("Capitol Database tables initialized");
+
+			int version = getSchemaVersion();
+			runMigrations(version);
+
 			Capitol.LOGGER.info("Capitol Database initialized");
 
 			Capitol.LOGGER.info("Warming Cache");
@@ -120,11 +122,14 @@ public class DatabaseManager {
 		}
 	}
 
-	public static int SCHEMA_VERSION = 1;
+	public static int SCHEMA_VERSION = 2;
 	//Will be used for DB migrations ect
 	private static void runMigrations(int current) throws SQLException {
 		if (SCHEMA_VERSION == current){
 			return;
+		}
+		if (current == 0) { // a schema of 0 means that the database is brand new, thus no migrations are needed
+			setSchemaVersion(SCHEMA_VERSION);
 		}
 		Capitol.LOGGER.info("Schema out of date, updating to version " + SCHEMA_VERSION + " from version " + current);
 		int updates = SCHEMA_VERSION - current;
@@ -133,7 +138,7 @@ public class DatabaseManager {
 			// E.G, current version 2 -> desired version 4 will result in versions
 			// 3 & 4 being run
 			switch (version) {
-				case 1:
+				case 2:
 					try (Statement stmt = connection.createStatement()) {
 						stmt.execute("ALTER TABLE team_roles ADD COLUMN color INTEGER NOT NULL DEFAULT -1;");
 					}

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -130,6 +130,7 @@ public class DatabaseManager {
 		}
 		if (current == 0) { // a schema of 0 means that the database is brand new, thus no migrations are needed
 			setSchemaVersion(SCHEMA_VERSION);
+			return;
 		}
 		Capitol.LOGGER.info("Schema out of date, updating to version " + SCHEMA_VERSION + " from version " + current);
 		int updates = SCHEMA_VERSION - current;

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -122,7 +122,7 @@ public class DatabaseManager {
 		}
 	}
 
-	public static int SCHEMA_VERSION = 2;
+	public static int SCHEMA_VERSION = 1;
 	//Will be used for DB migrations ect
 	private static void runMigrations(int current) throws SQLException {
 		if (SCHEMA_VERSION == current){
@@ -139,7 +139,7 @@ public class DatabaseManager {
 			// E.G, current version 2 -> desired version 4 will result in versions
 			// 3 & 4 being run
 			switch (version) {
-				case 2:
+				case 1:
 					try (Statement stmt = connection.createStatement()) {
 						stmt.execute("ALTER TABLE team_roles ADD COLUMN color INTEGER NOT NULL DEFAULT -1;");
 					}

--- a/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
+++ b/src/main/java/com/createcivilization/capitol/common/managers/DatabaseManager.java
@@ -67,6 +67,7 @@ public class DatabaseManager {
 					"team_id TEXT NOT NULL," +
 					"name TEXT NOT NULL," +
 					"permissions INTEGER NOT NULL DEFAULT 0," +
+					"color INTEGER NOT NULL DEFAULT -1,"+
 					"UNIQUE (team_id, name)," +
 					"FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE)"
 			);

--- a/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
+++ b/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
@@ -335,7 +335,7 @@ public class CapitolDatabase extends Database {
 			throw new RuntimeException(e);
 		}
 
-		addRole(team, TeamRole.OWNER_ROLE_NAME, TeamRole.ownerPermissions());
+		addRole(team, TeamRole.OWNER_ROLE_NAME, TeamRole.ownerPermissions(), new Color(0x800080));
 		addRole(team, TeamRole.DEFAULT_ROLE_NAME, TeamRole.defaultPermissions());
 	}
 

--- a/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
+++ b/src/main/java/com/createcivilization/capitol/common/modules/database/CapitolDatabase.java
@@ -8,9 +8,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 
+import java.awt.*;
 import java.sql.*;
 import java.time.Instant;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CapitolDatabase extends Database {
@@ -78,18 +80,30 @@ public class CapitolDatabase extends Database {
 	 * @param team        the team this role belongs to
 	 * @param name        the role name (e.g. "owner", "default")
 	 * @param permissions the bitfield of {@link Permission} flags
+	 * @param color       the color this role will override to for nation tags
 	 */
-	public void addRole(Team team, String name, long permissions) {
+	public void addRole(Team team, String name, long permissions, Color color) {
 		try (PreparedStatement ps = getConnection().prepareStatement(
-			"INSERT INTO team_roles (team_id, name, permissions) VALUES (?, ?, ?)")) {
+			"INSERT INTO team_roles (team_id, name, permissions, color) VALUES (?, ?, ?, ?)")) {
 			ps.setString(1, team.getId().toString());
 			ps.setString(2, name);
 			ps.setLong(3, permissions);
+			ps.setInt(4, color == null ? -1 : color.getRGB()); // -1 if the role has no associated color
 			ps.execute();
 		} catch (SQLException e) {
 			Capitol.LOGGER.error("Error while adding role to database.", e);
 			throw new RuntimeException(e);
 		}
+	}
+	/**
+	 * Inserts a new role into the {@code team_roles} table.
+	 *
+	 * @param team        the team this role belongs to
+	 * @param name        the role name (e.g. "owner", "default")
+	 * @param permissions the bitfield of {@link Permission} flags
+	 */
+	public void addRole(Team team, String name, long permissions) {
+		addRole(team, name, permissions, null);
 	}
 
 	/**
@@ -196,6 +210,19 @@ public class CapitolDatabase extends Database {
 			ps.execute();
 		} catch (SQLException e) {
 			Capitol.LOGGER.error("Error while updating role name in database.", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void updateRoleColor(Team team, String roleName, Color color) {
+		try (PreparedStatement ps = getConnection().prepareStatement(
+			"UPDATE team_roles SET color = ? WHERE team_id = ? AND name = ?")) {
+			ps.setInt(1, color == null ? -1 : color.getRGB());
+			ps.setString(2, team.getId().toString());
+			ps.setString(3, roleName);
+			ps.execute();
+		} catch (SQLException e) {
+			Capitol.LOGGER.error("Error while updating role color in database.", e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/com/createcivilization/capitol/server/commands/invite/InviteCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/invite/InviteCommand.java
@@ -38,7 +38,7 @@ public class InviteCommand {
 	}
 
 	private static int acceptInvite(CommandContext<CommandSourceStack> context) {
-		Player player = context.getSource().getPlayer();
+		ServerPlayer player = context.getSource().getPlayer();
 		if (player == null) return 0;
 
 		Team team = resolveInvitedTeam(context, player);
@@ -47,6 +47,9 @@ public class InviteCommand {
 		TeamRole role = DatabaseManager.database.getDefaultRole(team);
 		DatabaseManager.database.addPlayerToTeam(player, team, role);
 		InviteHandler.clearInvites(player);
+
+		player.refreshDisplayName();
+		player.refreshTabListName(); // needs to be a ServerPlayer for this.
 
 		MutableComponent joinMsg = Component.translatable("commands.capitol.invites.join.announcement",
 			Component.literal(player.getName().getString()).withStyle(ChatFormatting.WHITE),

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamCommand.java
@@ -1,5 +1,6 @@
 package com.createcivilization.capitol.server.commands.team;
 
+import com.createcivilization.capitol.common.config.CapitolConfig;
 import com.createcivilization.capitol.common.data.*;
 import com.createcivilization.capitol.common.managers.DatabaseManager;
 import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
@@ -197,6 +198,11 @@ public class TeamCommand {
 			StringArgumentType.getString(context, "color")
 		).replace("#", "");
 		String tag = StringArgumentType.getString(context, "tag");
+
+		if (tag.length() > CapitolConfig.TEAM_TAG_MAX_LENGTH.get()) {
+			context.getSource().sendFailure(Component.translatable("commands.capitol.team.create.tag_too_long", CapitolConfig.TEAM_TAG_MAX_LENGTH.get()).withStyle(ChatFormatting.RED));
+			return 0;
+		}
 
 		String description;
 		try {

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamCommand.java
@@ -339,4 +339,8 @@ public class TeamCommand {
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.disband.success").withStyle(ChatFormatting.GREEN), true);
 		return 1;
 	}
+
+	public static Map<String, String> getNamedColors() {
+		return NAMED_COLORS;
+	}
 }

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -10,10 +10,8 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.*;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -11,8 +11,13 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextColor;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
+import net.minecraft.world.entity.player.Player;
 
+import javax.xml.crypto.Data;
+import java.awt.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,52 +31,116 @@ class TeamRoleCommand {
 					.executes(TeamRoleCommand::createRole)))
 			.then(Commands.literal("edit")
 				.then(Commands.argument("role_name", StringArgumentType.word())
-				.suggests((context, builder) -> {
-					CapitolDatabase database = DatabaseManager.database;
-					Team team = database.getPlayerTeam(context.getSource().getPlayer());
-					if (team == null) {
-						builder.suggest("YOU ARE NOT IN A TEAM");
+					.suggests((context, builder) -> {
+						CapitolDatabase database = DatabaseManager.database;
+						Team team = database.getPlayerTeam(context.getSource().getPlayer());
+						if (team == null) {
+							builder.suggest("YOU ARE NOT IN A TEAM");
+							return builder.buildFuture();
+						}
+						List<TeamRole> roles = database.getTeamRoles(team);
+						for (TeamRole role : roles) {
+							builder.suggest(role.name());
+						}
 						return builder.buildFuture();
-					}
-					List<TeamRole> roles = database.getTeamRoles(team);
-					for (TeamRole role : roles) {
-						builder.suggest(role.name());
-					}
-					return builder.buildFuture();
-				})
-				.then(Commands.literal("assign")
-					.then(Commands.argument("player", StringArgumentType.string())
-						.suggests((context, builder) -> {
-							CapitolDatabase database = DatabaseManager.database;
-							Team team = database.getPlayerTeam(context.getSource().getPlayer());
-							if (team == null) {
-								builder.suggest("YOU ARE NOT IN A TEAM");
+					})
+					.then(Commands.literal("assign")
+						.then(Commands.argument("player", StringArgumentType.string())
+							.suggests((context, builder) -> {
+								CapitolDatabase database = DatabaseManager.database;
+								Team team = database.getPlayerTeam(context.getSource().getPlayer());
+								if (team == null) {
+									builder.suggest("YOU ARE NOT IN A TEAM");
+									return builder.buildFuture();
+								}
+								List<TeamMember> members = database.getTeamMembers(team);
+								GameProfileCache profileCache = context.getSource().getServer().getProfileCache();
+								for (TeamMember member : members) {
+									profileCache.get(member.playerUUID()).ifPresent(
+										gameProfile -> builder.suggest(gameProfile.getName())
+									);
+								}
 								return builder.buildFuture();
-							}
-							List<TeamMember> members = database.getTeamMembers(team);
-							GameProfileCache profileCache = context.getSource().getServer().getProfileCache();
-							for (TeamMember member : members) {
-								profileCache.get(member.playerUUID()).ifPresent(
-									gameProfile -> builder.suggest(gameProfile.getName())
-								);
-							}
-							return builder.buildFuture();
-						})
-						.executes(TeamRoleCommand::assignRole)))
-				.then(Commands.literal("permission")
-					.then(Commands.argument("permission_value", StringArgumentType.word())
-						.suggests((context, builder) -> {
-							for (Permission perm : Permission.values()) {
-								builder.suggest(perm.name().toLowerCase());
-							}
-							return builder.buildFuture();
-						})
-						.executes(TeamRoleCommand::editRolePerms)))
-				.then(Commands.literal("name")
-					.then(Commands.argument("new_name", StringArgumentType.string())
-						.executes(TeamRoleCommand::editRoleName)))
-				.then(Commands.literal("remove")
-					.executes(TeamRoleCommand::removeRole))));
+							})
+							.executes(TeamRoleCommand::assignRole)))
+					.then(Commands.literal("permission")
+						.then(Commands.argument("permission_value", StringArgumentType.word())
+							.suggests((context, builder) -> {
+								for (Permission perm : Permission.values()) {
+									builder.suggest(perm.name().toLowerCase());
+								}
+								return builder.buildFuture();
+							})
+							.executes(TeamRoleCommand::editRolePerms)))
+					.then(Commands.literal("name")
+						.then(Commands.argument("new_name", StringArgumentType.string())
+							.executes(TeamRoleCommand::editRoleName)))
+					.then(Commands.literal("remove")
+						.executes(TeamRoleCommand::removeRole))
+					.then(Commands.literal("color")
+						.then(Commands.argument("new_color", StringArgumentType.string())
+							.suggests((context, builder) -> {
+								TeamCommand.getNamedColors().keySet().forEach(builder::suggest);
+								builder.suggest("none");
+								return builder.buildFuture();
+							})
+							.executes(TeamRoleCommand::setColor)))
+				));
+
+	}
+
+	private static int setColor(CommandContext<CommandSourceStack> context) {
+		CapitolDatabase database = DatabaseManager.database;
+		var player = context.getSource().getPlayer();
+		if (player == null) {
+			return failCommand(context, "commands.capitol.command_source_was_console_error");
+		}
+
+		Team team = database.getPlayerTeam(player);
+		if (team == null) {
+			return failCommand(context, "commands.capitol.not_in_team_error");
+		}
+
+		if (!Permission.MANAGE_ROLES.hasPermission(database.getPlayerPermission(player, team))) {
+			return failCommand(context, "commands.capitol.team.role.no_manage_permission");
+		}
+		String roleName = StringArgumentType.getString(context, "role_name");
+
+		TeamRole role = database.getRoleByName(team, roleName);
+
+		if (role == null) {
+			return failCommand(context, "commands.capitol.team.role.color.failure", roleName, team.getName());
+		}
+
+		if (StringArgumentType.getString(context, "new_color").equalsIgnoreCase("none")) {
+			database.updateRoleColor(team, roleName, null);
+
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.color.clear.success",
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA)), true);
+		} else {
+			String hex = TeamCommand.getNamedColors().getOrDefault(
+				StringArgumentType.getString(context, "new_color").toLowerCase(),
+				StringArgumentType.getString(context, "new_color")
+			).replace("#", "");
+			Color color = new Color((int) Long.parseLong(hex, 16), true);
+
+			database.updateRoleColor(team, roleName, color);
+
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.color.success",
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(hex).withStyle(style -> style.withColor(TextColor.fromRgb(color.getRGB())))
+					.withStyle(ChatFormatting.GRAY)), true);
+		}
+
+		for (TeamMember member : database.getTeamMembers(team)) {
+			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
+			if (online != null) {
+				online.refreshDisplayName();
+				online.refreshTabListName();
+			}
+		}
+
+		return 1;
 	}
 
 	private static int createRole(CommandContext<CommandSourceStack> context) {
@@ -93,8 +162,8 @@ class TeamRoleCommand {
 
 		database.addRole(team, roleName, 0);
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.create.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA),
-			Component.literal(team.getName()).withStyle(ChatFormatting.GOLD))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(team.getName()).withStyle(ChatFormatting.GOLD))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -132,8 +201,16 @@ class TeamRoleCommand {
 
 		database.deleteRole(team, roleName);
 
+		for (TeamMember member : database.getTeamMembers(team)) { // Sweeping update, applies to all players in a team currently online.
+			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
+			if (online != null) {
+				online.refreshDisplayName();
+				online.refreshTabListName();
+			}
+		}
+
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.remove.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -182,9 +259,16 @@ class TeamRoleCommand {
 
 		database.updatePlayerRole(gameProfile.getId(), team, role);
 
+		ServerPlayer target = context.getSource().getServer().getPlayerList().getPlayer(gameProfile.getId()); // Specifically refreshes the targeted player
+		if (target != null) {
+			target.refreshTabListName();
+			target.refreshDisplayName();
+		}
+
+
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.assign.success",
-			Component.literal(gameProfile.getName()).withStyle(ChatFormatting.WHITE),
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(gameProfile.getName()).withStyle(ChatFormatting.WHITE),
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -225,8 +309,8 @@ class TeamRoleCommand {
 		database.updateRoleName(team, roleName, newRoleName);
 
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.name.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA),
-			Component.literal(newRoleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(newRoleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -270,10 +354,10 @@ class TeamRoleCommand {
 		database.updateRolePermissions(team, roleName, rolePerms);
 
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.permission_toggle",
-			Component.literal(permissionName.toLowerCase()).withStyle(ChatFormatting.AQUA),
-			Component.literal(roleName).withStyle(ChatFormatting.GOLD),
-			Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
-			Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
+				Component.literal(permissionName.toLowerCase()).withStyle(ChatFormatting.AQUA),
+				Component.literal(roleName).withStyle(ChatFormatting.GOLD),
+				Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
+				Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -14,9 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
-import net.minecraft.world.entity.player.Player;
 
-import javax.xml.crypto.Data;
 import java.awt.*;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -33,7 +33,7 @@ class TeamRoleCommand {
 						CapitolDatabase database = DatabaseManager.database;
 						Team team = database.getPlayerTeam(context.getSource().getPlayer());
 						if (team == null) {
-							builder.suggest("YOU ARE NOT IN A TEAM");
+							builder.suggest(Component.translatable("commands.capitol.not_in_team_error").toString());
 							return builder.buildFuture();
 						}
 						List<TeamRole> roles = database.getTeamRoles(team);
@@ -48,7 +48,7 @@ class TeamRoleCommand {
 								CapitolDatabase database = DatabaseManager.database;
 								Team team = database.getPlayerTeam(context.getSource().getPlayer());
 								if (team == null) {
-									builder.suggest("YOU ARE NOT IN A TEAM");
+									builder.suggest(Component.translatable("commands.capitol.not_in_team_error").toString());
 									return builder.buildFuture();
 								}
 								List<TeamMember> members = database.getTeamMembers(team);

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -121,7 +121,7 @@ class TeamRoleCommand {
 				StringArgumentType.getString(context, "new_color").toLowerCase(),
 				StringArgumentType.getString(context, "new_color")
 			).replace("#", "");
-			Color color = new Color((int) Long.parseLong(hex, 16), true);
+			Color color = new Color(Integer.parseInt(hex, 16), true);
 
 			database.updateRoleColor(team, roleName, color);
 

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.createcivilization.capitol.common.managers.DatabaseManager.database;
+
 class TeamRoleCommand {
 
 	static LiteralArgumentBuilder<CommandSourceStack> register() {
@@ -131,13 +133,7 @@ class TeamRoleCommand {
 					.withStyle(ChatFormatting.GRAY)), true);
 		}
 
-		for (TeamMember member : database.getTeamMembers(team)) {
-			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
-			if (online != null) {
-				online.refreshDisplayName();
-				online.refreshTabListName();
-			}
-		}
+		refreshTeamPlayers(context, team);
 
 		return 1;
 	}
@@ -200,13 +196,7 @@ class TeamRoleCommand {
 
 		database.deleteRole(team, roleName);
 
-		for (TeamMember member : database.getTeamMembers(team)) { // Sweeping update, applies to all players in a team currently online.
-			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
-			if (online != null) {
-				online.refreshDisplayName();
-				online.refreshTabListName();
-			}
-		}
+		refreshTeamPlayers(context, team);
 
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.remove.success",
 				Component.literal(roleName).withStyle(ChatFormatting.AQUA))
@@ -402,6 +392,16 @@ class TeamRoleCommand {
 				Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
 			.withStyle(ChatFormatting.GRAY), true);*/
 		return 1;
+	}
+
+	public static void refreshTeamPlayers(CommandContext<CommandSourceStack> context, Team team) {
+		for (TeamMember member : database.getTeamMembers(team)) {
+			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
+			if (online != null) {
+				online.refreshDisplayName();
+				online.refreshTabListName();
+			}
+		}
 	}
 
 	static int failCommand(CommandContext<CommandSourceStack> context, String key, Object... args) {

--- a/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
+++ b/src/main/java/com/createcivilization/capitol/server/commands/team/TeamRoleCommand.java
@@ -17,6 +17,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
 
+import java.awt.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -30,53 +31,117 @@ class TeamRoleCommand {
 					.executes(TeamRoleCommand::createRole)))
 			.then(Commands.literal("edit")
 				.then(Commands.argument("role_name", StringArgumentType.word())
-				.suggests((context, builder) -> {
-					CapitolDatabase database = DatabaseManager.database;
-					Team team = database.getPlayerTeam(context.getSource().getPlayer());
-					if (team == null) {
-						builder.suggest("YOU ARE NOT IN A TEAM");
+					.suggests((context, builder) -> {
+						CapitolDatabase database = DatabaseManager.database;
+						Team team = database.getPlayerTeam(context.getSource().getPlayer());
+						if (team == null) {
+							builder.suggest("YOU ARE NOT IN A TEAM");
+							return builder.buildFuture();
+						}
+						List<TeamRole> roles = database.getTeamRoles(team);
+						for (TeamRole role : roles) {
+							builder.suggest(role.name());
+						}
 						return builder.buildFuture();
-					}
-					List<TeamRole> roles = database.getTeamRoles(team);
-					for (TeamRole role : roles) {
-						builder.suggest(role.name());
-					}
-					return builder.buildFuture();
-				})
-				.then(Commands.literal("assign")
-					.then(Commands.argument("player", StringArgumentType.string())
-						.suggests((context, builder) -> {
-							CapitolDatabase database = DatabaseManager.database;
-							Team team = database.getPlayerTeam(context.getSource().getPlayer());
-							if (team == null) {
-								builder.suggest("YOU ARE NOT IN A TEAM");
+					})
+					.then(Commands.literal("assign")
+						.then(Commands.argument("player", StringArgumentType.string())
+							.suggests((context, builder) -> {
+								CapitolDatabase database = DatabaseManager.database;
+								Team team = database.getPlayerTeam(context.getSource().getPlayer());
+								if (team == null) {
+									builder.suggest("YOU ARE NOT IN A TEAM");
+									return builder.buildFuture();
+								}
+								List<TeamMember> members = database.getTeamMembers(team);
+								GameProfileCache profileCache = context.getSource().getServer().getProfileCache();
+								for (TeamMember member : members) {
+									profileCache.get(member.playerUUID()).ifPresent(
+										gameProfile -> builder.suggest(gameProfile.getName())
+									);
+								}
 								return builder.buildFuture();
-							}
-							List<TeamMember> members = database.getTeamMembers(team);
-							GameProfileCache profileCache = context.getSource().getServer().getProfileCache();
-							for (TeamMember member : members) {
-								profileCache.get(member.playerUUID()).ifPresent(
-									gameProfile -> builder.suggest(gameProfile.getName())
-								);
-							}
-							return builder.buildFuture();
-						})
-						.executes(TeamRoleCommand::assignRole)))
-				.then(Commands.literal("permission")
-					.then(Commands.argument("permission_value", StringArgumentType.word())
-						.suggests((context, builder) -> {
-							for (Permission perm : Permission.values()) {
-								builder.suggest(perm.name().toLowerCase());
-							}
-							return builder.buildFuture();
-						})
-						.executes(TeamRoleCommand::editRolePerms)))
+							})
+							.executes(TeamRoleCommand::assignRole)))
+					.then(Commands.literal("permission")
+						.then(Commands.argument("permission_value", StringArgumentType.word())
+							.suggests((context, builder) -> {
+								for (Permission perm : Permission.values()) {
+									builder.suggest(perm.name().toLowerCase());
+								}
+								return builder.buildFuture();
+							})
+							.executes(TeamRoleCommand::editRolePerms)))
 					.then(Commands.literal("list").executes(TeamRoleCommand::viewRolePermList))
-				.then(Commands.literal("name")
-					.then(Commands.argument("new_name", StringArgumentType.string())
-						.executes(TeamRoleCommand::editRoleName)))
-				.then(Commands.literal("remove")
-					.executes(TeamRoleCommand::removeRole))));
+					.then(Commands.literal("name")
+						.then(Commands.argument("new_name", StringArgumentType.string())
+							.executes(TeamRoleCommand::editRoleName)))
+					.then(Commands.literal("remove")
+						.executes(TeamRoleCommand::removeRole))
+					.then(Commands.literal("color")
+						.then(Commands.argument("new_color", StringArgumentType.string())
+							.suggests((context, builder) -> {
+								TeamCommand.getNamedColors().keySet().forEach(builder::suggest);
+								builder.suggest("none");
+								return builder.buildFuture();
+							})
+							.executes(TeamRoleCommand::setColor)))
+				));
+
+	}
+
+	private static int setColor(CommandContext<CommandSourceStack> context) {
+		CapitolDatabase database = DatabaseManager.database;
+		var player = context.getSource().getPlayer();
+		if (player == null) {
+			return failCommand(context, "commands.capitol.command_source_was_console_error");
+		}
+
+		Team team = database.getPlayerTeam(player);
+		if (team == null) {
+			return failCommand(context, "commands.capitol.not_in_team_error");
+		}
+
+		if (!Permission.MANAGE_ROLES.hasPermission(database.getPlayerPermission(player, team))) {
+			return failCommand(context, "commands.capitol.team.role.no_manage_permission");
+		}
+		String roleName = StringArgumentType.getString(context, "role_name");
+
+		TeamRole role = database.getRoleByName(team, roleName);
+
+		if (role == null) {
+			return failCommand(context, "commands.capitol.team.role.color.failure", roleName, team.getName());
+		}
+
+		if (StringArgumentType.getString(context, "new_color").equalsIgnoreCase("none")) {
+			database.updateRoleColor(team, roleName, null);
+
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.color.clear.success",
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA)), true);
+		} else {
+			String hex = TeamCommand.getNamedColors().getOrDefault(
+				StringArgumentType.getString(context, "new_color").toLowerCase(),
+				StringArgumentType.getString(context, "new_color")
+			).replace("#", "");
+			Color color = new Color((int) Long.parseLong(hex, 16), true);
+
+			database.updateRoleColor(team, roleName, color);
+
+			context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.color.success",
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(hex).withStyle(style -> style.withColor(TextColor.fromRgb(color.getRGB())))
+					.withStyle(ChatFormatting.GRAY)), true);
+		}
+
+		for (TeamMember member : database.getTeamMembers(team)) {
+			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
+			if (online != null) {
+				online.refreshDisplayName();
+				online.refreshTabListName();
+			}
+		}
+
+		return 1;
 	}
 
 	private static int createRole(CommandContext<CommandSourceStack> context) {
@@ -98,8 +163,8 @@ class TeamRoleCommand {
 
 		database.addRole(team, roleName, 0);
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.create.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA),
-			Component.literal(team.getName()).withStyle(ChatFormatting.GOLD))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(team.getName()).withStyle(ChatFormatting.GOLD))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -137,8 +202,16 @@ class TeamRoleCommand {
 
 		database.deleteRole(team, roleName);
 
+		for (TeamMember member : database.getTeamMembers(team)) { // Sweeping update, applies to all players in a team currently online.
+			ServerPlayer online = context.getSource().getServer().getPlayerList().getPlayer(member.playerUUID());
+			if (online != null) {
+				online.refreshDisplayName();
+				online.refreshTabListName();
+			}
+		}
+
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.remove.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -187,9 +260,16 @@ class TeamRoleCommand {
 
 		database.updatePlayerRole(gameProfile.getId(), team, role);
 
+		ServerPlayer target = context.getSource().getServer().getPlayerList().getPlayer(gameProfile.getId()); // Specifically refreshes the targeted player
+		if (target != null) {
+			target.refreshTabListName();
+			target.refreshDisplayName();
+		}
+
+
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.assign.success",
-			Component.literal(gameProfile.getName()).withStyle(ChatFormatting.WHITE),
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(gameProfile.getName()).withStyle(ChatFormatting.WHITE),
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -230,8 +310,8 @@ class TeamRoleCommand {
 		database.updateRoleName(team, roleName, newRoleName);
 
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.team.role.name.success",
-			Component.literal(roleName).withStyle(ChatFormatting.AQUA),
-			Component.literal(newRoleName).withStyle(ChatFormatting.AQUA))
+				Component.literal(roleName).withStyle(ChatFormatting.AQUA),
+				Component.literal(newRoleName).withStyle(ChatFormatting.AQUA))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}
@@ -275,10 +355,10 @@ class TeamRoleCommand {
 		database.updateRolePermissions(team, roleName, rolePerms);
 
 		context.getSource().sendSuccess(() -> Component.translatable("commands.capitol.permission_toggle",
-			Component.literal(permissionName.toLowerCase()).withStyle(ChatFormatting.AQUA),
-			Component.literal(roleName).withStyle(ChatFormatting.GOLD),
-			Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
-			Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
+				Component.literal(permissionName.toLowerCase()).withStyle(ChatFormatting.AQUA),
+				Component.literal(roleName).withStyle(ChatFormatting.GOLD),
+				Component.literal(String.valueOf(oldState)).withStyle(oldState ? ChatFormatting.GREEN : ChatFormatting.RED),
+				Component.literal(String.valueOf(newState)).withStyle(newState ? ChatFormatting.GREEN : ChatFormatting.RED))
 			.withStyle(ChatFormatting.GRAY), true);
 		return 1;
 	}

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -48,10 +48,14 @@ public class NameFormatEvents {
 	}
 
 	public static Component getTag(Team team, TeamRole role) {
-		if (role.color() == null) {
-			return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
+		TextColor color;
+
+		if (role.color() != null) {
+			color = TextColor.fromRgb(role.color().getRGB());
 		} else {
-			return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(role.color().getRGB())));
+			color = TextColor.fromRgb(team.getColor().getRGB());
 		}
+
+		return Component.literal(team.getTag()).withStyle(style -> style.withColor(color));
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -51,13 +51,9 @@ public class NameFormatEvents {
 	}
 
 	public static Component getTag(Team team, TeamRole role) {
-		TextColor color;
+		boolean useRoleColor = CapitolConfig.ALLOW_PLAYER_ROLE_COLOURS.get() && role.color() != null;
 
-		if (CapitolConfig.ALLOW_PLAYER_ROLE_COLOURS.get() && role.color() != null) {
-			color = TextColor.fromRgb(role.color().getRGB());
-		} else {
-			color = TextColor.fromRgb(team.getColor().getRGB());
-		}
+		TextColor color = TextColor.fromRgb(useRoleColor ? role.color().getRGB() : team.getColor().getRGB());
 
 		return Component.literal(team.getTag()).withStyle(style -> style.withColor(color));
 	}

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -5,19 +5,12 @@ import com.createcivilization.capitol.common.config.CapitolConfig;
 import com.createcivilization.capitol.common.data.Team;
 import com.createcivilization.capitol.common.data.TeamRole;
 import com.createcivilization.capitol.common.managers.DatabaseManager;
-import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
-import com.createcivilization.capitol.common.modules.database.Database;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.ServerChatEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
-
-import javax.management.relation.Role;
 
 @EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
 public class NameFormatEvents {

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -1,6 +1,7 @@
 package com.createcivilization.capitol.server.events;
 
 import com.createcivilization.capitol.Capitol;
+import com.createcivilization.capitol.common.config.CapitolConfig;
 import com.createcivilization.capitol.common.data.Team;
 import com.createcivilization.capitol.common.managers.DatabaseManager;
 import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
@@ -19,10 +20,15 @@ import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 public class NameFormatEvents {
 	@SubscribeEvent
 	public static void onNameFormat(PlayerEvent.NameFormat event) { // Mainly for chat messages
+		if (!CapitolConfig.DISPLAY_TAGS_IN_CHAT.get()) {
+			return;
+		}
+
 		Team team = DatabaseManager.database.getPlayerTeam(event.getEntity().getUUID());
 		if (team == null) {
 			return;
 		}
+
 		Component prevName = event.getDisplayname(); // the spelling mistake in getDisplayname instead of getDisplayName lmao
 		Component tag = getTag(team);
 		event.setDisplayname(Component.literal("").append(tag).append(" ").append(prevName));
@@ -30,10 +36,15 @@ public class NameFormatEvents {
 
 	@SubscribeEvent
 	public static void onTabListNameFormat(PlayerEvent.TabListNameFormat event) { // Only for tab list
+		if (!CapitolConfig.DISPLAY_TAGS_IN_TAB_LIST.get()) {
+			return;
+		}
+
 		Team team = DatabaseManager.database.getPlayerTeam(event.getEntity().getUUID());
 		if (team == null) {
 			return;
 		}
+
 		Component tag = getTag(team);
 		event.setDisplayName(Component.literal("[").append(tag).append("] ").append(event.getEntity().getName()));
 	}

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -26,9 +26,11 @@ public class NameFormatEvents {
 		}
 		TeamRole role = DatabaseManager.database.getPlayerRole(event.getEntity(), team);
 
-		Component prevName = event.getDisplayname(); // the spelling mistake in getDisplayname instead of getDisplayName lmao
+		Component prevName = event.getDisplayname();
 		Component tag = getTag(team, role);
-		event.setDisplayname(Component.literal("").append(tag).append(" ").append(prevName));
+		// This is so we can easily preserve the previous name and team tag's styles
+		String formatted = CapitolConfig.TEAM_TAG_FORMAT.get().replaceAll("%t", "%1$s").replaceAll("%p", "%2$s");
+		event.setDisplayname(Component.translatable(formatted, tag, prevName));
 	}
 
 	@SubscribeEvent
@@ -44,7 +46,8 @@ public class NameFormatEvents {
 		TeamRole role = DatabaseManager.database.getPlayerRole(event.getEntity(), team);
 
 		Component tag = getTag(team, role);
-		event.setDisplayName(Component.literal("[").append(tag).append("] ").append(event.getEntity().getName()));
+		String formatted = CapitolConfig.TEAM_TAG_FORMAT.get().replaceAll("%t", "%1$s").replaceAll("%p", "%2$s");
+		event.setDisplayName(Component.translatable(formatted, tag, event.getDisplayName()));
 	}
 
 	public static Component getTag(Team team, TeamRole role) {

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -1,0 +1,28 @@
+package com.createcivilization.capitol.server.events;
+
+import com.createcivilization.capitol.Capitol;
+import com.createcivilization.capitol.common.data.Team;
+import com.createcivilization.capitol.common.managers.DatabaseManager;
+import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
+import com.createcivilization.capitol.common.modules.database.Database;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextColor;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+@EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
+public class NameFormatEvents {
+	@SubscribeEvent
+	public static void onNameFormat(PlayerEvent.NameFormat event) {
+		Team team = DatabaseManager.database.getTeam(event.getEntity().getUUID());
+		if (team == null) {
+			return;
+		}
+		Component prevName = event.getDisplayname();
+		Component tag = Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
+		event.setDisplayname(Component.literal("[").append(tag).append("] ").append(prevName));
+	}
+}

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -3,6 +3,7 @@ package com.createcivilization.capitol.server.events;
 import com.createcivilization.capitol.Capitol;
 import com.createcivilization.capitol.common.config.CapitolConfig;
 import com.createcivilization.capitol.common.data.Team;
+import com.createcivilization.capitol.common.data.TeamRole;
 import com.createcivilization.capitol.common.managers.DatabaseManager;
 import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
 import com.createcivilization.capitol.common.modules.database.Database;
@@ -16,6 +17,8 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.ServerChatEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
+import javax.management.relation.Role;
+
 @EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
 public class NameFormatEvents {
 	@SubscribeEvent
@@ -28,9 +31,10 @@ public class NameFormatEvents {
 		if (team == null) {
 			return;
 		}
+		TeamRole role = DatabaseManager.database.getPlayerRole(event.getEntity(), team);
 
 		Component prevName = event.getDisplayname(); // the spelling mistake in getDisplayname instead of getDisplayName lmao
-		Component tag = getTag(team);
+		Component tag = getTag(team, role);
 		event.setDisplayname(Component.literal("").append(tag).append(" ").append(prevName));
 	}
 
@@ -44,12 +48,17 @@ public class NameFormatEvents {
 		if (team == null) {
 			return;
 		}
+		TeamRole role = DatabaseManager.database.getPlayerRole(event.getEntity(), team);
 
-		Component tag = getTag(team);
+		Component tag = getTag(team, role);
 		event.setDisplayName(Component.literal("[").append(tag).append("] ").append(event.getEntity().getName()));
 	}
 
-	public static Component getTag(Team team) {
-		return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
+	public static Component getTag(Team team, TeamRole role) {
+		if (role.color() == null) {
+			return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
+		} else {
+			return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(role.color().getRGB())));
+		}
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -6,23 +6,39 @@ import com.createcivilization.capitol.common.managers.DatabaseManager;
 import com.createcivilization.capitol.common.modules.database.CapitolDatabase;
 import com.createcivilization.capitol.common.modules.database.Database;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.ServerChatEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
 @EventBusSubscriber(modid = Capitol.MOD_ID, value = Dist.DEDICATED_SERVER)
 public class NameFormatEvents {
 	@SubscribeEvent
-	public static void onNameFormat(PlayerEvent.NameFormat event) {
-		Team team = DatabaseManager.database.getTeam(event.getEntity().getUUID());
+	public static void onNameFormat(PlayerEvent.NameFormat event) { // Mainly for chat messages
+		Team team = DatabaseManager.database.getPlayerTeam(event.getEntity().getUUID());
 		if (team == null) {
 			return;
 		}
-		Component prevName = event.getDisplayname();
-		Component tag = Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
-		event.setDisplayname(Component.literal("[").append(tag).append("] ").append(prevName));
+		Component prevName = event.getDisplayname(); // the spelling mistake in getDisplayname instead of getDisplayName lmao
+		Component tag = getTag(team);
+		event.setDisplayname(Component.literal("").append(tag).append(" ").append(prevName));
+	}
+
+	@SubscribeEvent
+	public static void onTabListNameFormat(PlayerEvent.TabListNameFormat event) { // Only for tab list
+		Team team = DatabaseManager.database.getPlayerTeam(event.getEntity().getUUID());
+		if (team == null) {
+			return;
+		}
+		Component tag = getTag(team);
+		event.setDisplayName(Component.literal("[").append(tag).append("] ").append(event.getEntity().getName()));
+	}
+
+	public static Component getTag(Team team) {
+		return Component.literal(team.getTag()).withStyle(style -> style.withColor(TextColor.fromRgb(team.getColor().getRGB())));
 	}
 }

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -53,7 +53,7 @@ public class NameFormatEvents {
 	public static Component getTag(Team team, TeamRole role) {
 		TextColor color;
 
-		if (role.color() != null) {
+		if (CapitolConfig.ALLOW_PLAYER_ROLE_COLOURS.get() && role.color() != null) {
 			color = TextColor.fromRgb(role.color().getRGB());
 		} else {
 			color = TextColor.fromRgb(team.getColor().getRGB());

--- a/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
+++ b/src/main/java/com/createcivilization/capitol/server/events/NameFormatEvents.java
@@ -29,7 +29,7 @@ public class NameFormatEvents {
 		Component prevName = event.getDisplayname();
 		Component tag = getTag(team, role);
 		// This is so we can easily preserve the previous name and team tag's styles
-		String formatted = CapitolConfig.TEAM_TAG_FORMAT.get().replaceAll("%t", "%1$s").replaceAll("%p", "%2$s");
+		String formatted = CapitolConfig.TEAM_TAG_LIST_FORMAT.get().replace("%t", "%1$s").replace("%p", "%2$s");
 		event.setDisplayname(Component.translatable(formatted, tag, prevName));
 	}
 
@@ -46,8 +46,8 @@ public class NameFormatEvents {
 		TeamRole role = DatabaseManager.database.getPlayerRole(event.getEntity(), team);
 
 		Component tag = getTag(team, role);
-		String formatted = CapitolConfig.TEAM_TAG_FORMAT.get().replaceAll("%t", "%1$s").replaceAll("%p", "%2$s");
-		event.setDisplayName(Component.translatable(formatted, tag, event.getDisplayName()));
+		String formatted = CapitolConfig.TEAM_TAG_LIST_FORMAT.get().replace("%t", "%1$s").replace("%p", "%2$s");
+		event.setDisplayName(Component.translatable(formatted, tag, event.getEntity().getName()));
 	}
 
 	public static Component getTag(Team team, TeamRole role) {

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -39,6 +39,7 @@
 
 	"commands.capitol.team.create.already_in_team": "You are already in a team, please leave before creating a new one",
 	"commands.capitol.team.create.name_exists": "A team with that name already exists.",
+	"commands.capitol.team.create.tag_too_long": "Tag is too long, max length of %d",
 	"commands.capitol.team.create.invalid_color": "Invalid hex color: #%s",
 	"commands.capitol.team.create.success": "Team %s created!",
 

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -38,6 +38,7 @@
 
 	"commands.capitol.team.create.already_in_team": "You are already in a team, please leave before creating a new one",
 	"commands.capitol.team.create.name_exists": "A team with that name already exists.",
+	"commands.capitol.team.create.tag_too_long": "Tag is too long, max length of %d",
 	"commands.capitol.team.create.invalid_color": "Invalid hex color: #%s",
 	"commands.capitol.team.create.success": "Team %s created!",
 

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -72,6 +72,9 @@
 	"commands.capitol.team.role.edit.no_default": "You cannot edit default role name.",
 	"commands.capitol.team.role.name.success": "Renamed role %s → %s",
 
+	"commands.capitol.team.role.color.success": "Set role %s's color to %s",
+	"commands.capitol.team.role.color.clear.success": "Cleared role %s's color",
+
 	"commands.capitol.team.player.no_permission": "You do not have permission to manage individual permissions",
 	"commands.capitol.team.player.perms.reset": "Individual permissions for %s reset to role defaults.",
 

--- a/src/main/resources/assets/capitol/lang/en_us.json
+++ b/src/main/resources/assets/capitol/lang/en_us.json
@@ -73,6 +73,9 @@
 	"commands.capitol.team.role.edit.no_default": "You cannot edit default role name.",
 	"commands.capitol.team.role.name.success": "Renamed role %s → %s",
 
+	"commands.capitol.team.role.color.success": "Set role %s's color to %s",
+	"commands.capitol.team.role.color.clear.success": "Cleared role %s's color",
+
 	"commands.capitol.team.role.permission_list.role": "Role: ",
 	"commands.capitol.team.role.permission_list.hover": "Click to swap permissions",
 


### PR DESCRIPTION
Adds tags that appear next to players names in the tab list and in-game chat.
Both are configurable, letting server owners turn them on and off individually.

The tags follow the color of the nation, or if the role assigned to the player has an override color it follows that.
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/a91eabdc-7b82-416e-939a-961bff13fde4" />
In this example the owner has a color of purple, whereas the regular member of the nation has orange (which is the teams color).

The owner role now defaults to purple.

The tag uses the already existing tag value given to each team and it's now capped to 3 characters by default, but it is configurable.
